### PR TITLE
added . to Quantum import.

### DIFF
--- a/device_tracker/quantum_gateway.py
+++ b/device_tracker/quantum_gateway.py
@@ -5,7 +5,7 @@ from http.cookies import SimpleCookie
 import json
 import requests
 import voluptuous as vol
-from Quantum import Quantum
+from .Quantum import Quantum
 
 from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
                                                      DeviceScanner)


### PR DESCRIPTION
this was an insidious bug, HA did not throw an error saying there was a problem importing, but rather said 'custem_components.device_tracker has no attribute setup'