### PR TITLE
Resolving error caused by invalid javascript syntax failing to parse.

### DIFF
--- a/src/quantum_gateway.py
+++ b/src/quantum_gateway.py
@@ -163,7 +163,10 @@ class Gateway3100(Gateway):
                 if data['activity'] == 1:
                     connected_devices[data['mac']] = data['hostname']
 
-        esprima.parseScript(res.text, {}, visitor)
+        lines = res.text.split("\n")
+        for line in lines:
+            if "known_device_list" in line:
+                esprima.parseScript(line, {}, visitor)
 
         return connected_devices
 


### PR DESCRIPTION
This change only attempts to parse the single line containing the 'known_device_list'