### PR TITLE
Feat/connected devices ip address

### DIFF
--- a/src/quantum_gateway.py
+++ b/src/quantum_gateway.py
@@ -294,3 +294,9 @@ class QuantumGatewayScanner:
 
     def get_device_name(self, device: str) -> str:
         return self.connected_devices.get(device)
+
+    def get_all_devices(self):
+        self.all_devices = {}
+        if self._gateway.check_auth():
+            self.all_devices = self._gateway.get_all_devices()
+        return self.all_devices

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -72,6 +72,17 @@ class TestScanner(unittest.TestCase):
             scanner.scan_devices()
             self.assertEqual(scanner.get_device_name("mac_address"), "hostname")
 
+    def test_get_all_devices(self):
+        devices = {"mac_address": DeviceInfo("mac_address", "hostname", True, None)}
+        with mock.patch.object(QuantumGatewayScanner, "_get_gateway") as mock_get_gateway:
+            mock_gateway = mock.create_autospec(Gateway)
+            mock_gateway.check_auth.return_value = True
+            mock_gateway.get_all_devices.return_value = devices
+            mock_get_gateway.return_value = mock_gateway
+
+            scanner = QuantumGatewayScanner("192.168.1.1", "password")
+            self.assertEqual(scanner.get_all_devices(), devices)
+
 
 @requests_mock.Mocker()
 class TestGateway1100(unittest.TestCase):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -155,8 +155,12 @@ class TestGateway3100(unittest.TestCase):
     DEVICE_INFO_MATCHER = re.compile('^.*/cgi_owl.js$')
     LOGOUT_MATCHER = re.compile('^.*/logout.cgi$')
 
-    LOGGED_OUT_STATUS_JSON = {"islogin": "0"}
-    LOGGED_IN_STATUS_JSON = {"islogin": "1", "token": "token_value"}
+    LOGGED_OUT_STATUS_JSON = {"islogin": "0", "loginToken": ""}
+    LOGGED_IN_STATUS_JSON = {
+        "islogin": "1",
+        "token": "token_value",
+        "loginToken": "login_token"
+    }
 
     def setUp(self):
         self.host = "192.168.23.16"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -181,10 +181,7 @@ class TestGateway3100(unittest.TestCase):
 
     def test_get_connected_devices(self, m):
         device_info_response_text = """
-        addROD("known_device_list", { "known_devices": [
-            { "mac": "xx:xx:xx:xx:xx:xx", "hostname": "active_device", "activity": 1 },
-            { "mac": "xx:xx:xx:xx:xx:ab", "hostname": "inactive_device", "activity": 0 }
-        ] });
+        addROD("known_device_list", { "known_devices": [{ "mac": "xx:xx:xx:xx:xx:xx", "hostname": "active_device", "activity": 1 },{ "mac": "xx:xx:xx:xx:xx:ab", "hostname": "inactive_device", "activity": 0 }] });
         """
 
         self._match_successful_login(m)


### PR DESCRIPTION
This PR updates the `QuantumGatewayScanner` class with `get_all_devices` method that exposes all devices the router knows about. The new method returns a `Dict[str, DeviceInfo]`. `DeviceInfo` is a new dataclass introduced as part of this PR. It contains a device's mac address, hostname, connection status, and IP address.

Unfortunately, I only have a model 1100, so the new method always returns a `None` IP address for model 3100.

I'd like to expose the device IP addresses to Home Assistant, and so I'm planning on also updating the quantum gateway integration to use the new device tracker API in Home Assistant. Let me know if you have any feedback, I'm happy to make changes to the approach I chose.